### PR TITLE
Upgrade AGP, Jetpack Compose, Kotlin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,7 +38,7 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion '1.4.20'
+        kotlinCompilerVersion kotlin_version
     }
 }
 
@@ -57,7 +57,7 @@ dependencies {
     def room_version = '2.2.5'
     def androidx_hilt_version = '1.0.0-alpha02'
     def lifecycle_version = '2.2.0'
-    def nav_compose_version = "1.0.0-alpha03"
+    def nav_compose_version = "1.0.0-alpha04"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.core:core-ktx:1.3.2'

--- a/app/src/main/java/com/sergiobelda/todometer/ui/components/TextField.kt
+++ b/app/src/main/java/com/sergiobelda/todometer/ui/components/TextField.kt
@@ -17,7 +17,6 @@
 package com.sergiobelda.todometer.ui.components
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.OutlinedTextField
@@ -32,14 +31,14 @@ import com.sergiobelda.todometer.ui.theme.MaterialTypography
 
 @Composable
 fun TextField(
+    modifier: Modifier = Modifier,
     value: String,
     onValueChanged: (String) -> Unit,
     label: @Composable (() -> Unit)? = null,
     isErrorValue: Boolean = false,
     errorMessage: String = "",
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
-    onImeActionPerformed: (ImeAction, SoftwareKeyboardController?) -> Unit = { _, _ -> },
-    modifier: Modifier = Modifier.fillMaxWidth(),
+    onImeActionPerformed: (ImeAction, SoftwareKeyboardController?) -> Unit = { _, _ -> }
 ) {
     Column(
         modifier = Modifier.padding(

--- a/app/src/main/java/com/sergiobelda/todometer/ui/task/AddTaskScreen.kt
+++ b/app/src/main/java/com/sergiobelda/todometer/ui/task/AddTaskScreen.kt
@@ -17,6 +17,7 @@
 package com.sergiobelda.todometer.ui.task
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -34,6 +35,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.savedinstancestate.savedInstanceState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -84,7 +86,8 @@ fun AddTaskScreen(
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Sentences,
                         imeAction = ImeAction.Next
-                    )
+                    ),
+                    modifier = Modifier.fillMaxWidth()
                 )
                 TextField(
                     value = taskDescription,
@@ -94,7 +97,8 @@ fun AddTaskScreen(
                     keyboardOptions = KeyboardOptions(
                         capitalization = KeyboardCapitalization.Sentences,
                         imeAction = ImeAction.Done
-                    )
+                    ),
+                    modifier = Modifier.fillMaxWidth()
                 )
                 ProjectSelector(radioOptions, selectedProject, onProjectSelected)
             }

--- a/app/src/main/java/com/sergiobelda/todometer/ui/task/EditTaskScreen.kt
+++ b/app/src/main/java/com/sergiobelda/todometer/ui/task/EditTaskScreen.kt
@@ -17,6 +17,7 @@
 package com.sergiobelda.todometer.ui.task
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -35,6 +36,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.savedinstancestate.savedInstanceState
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -89,7 +91,8 @@ fun EditTaskScreen(
                         keyboardOptions = KeyboardOptions(
                             capitalization = KeyboardCapitalization.Sentences,
                             imeAction = ImeAction.Next
-                        )
+                        ),
+                        modifier = Modifier.fillMaxWidth()
                     )
                     TextField(
                         value = taskDescription,
@@ -99,7 +102,8 @@ fun EditTaskScreen(
                         keyboardOptions = KeyboardOptions(
                             capitalization = KeyboardCapitalization.Sentences,
                             imeAction = ImeAction.Done
-                        )
+                        ),
+                        modifier = Modifier.fillMaxWidth()
                     )
                     ProjectSelector(radioOptions, selectedProject, onProjectSelected)
                 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,16 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_version = '1.0.0-alpha08'
+        compose_version = '1.0.0-alpha09'
         dagger_hilt_version = '2.28.3-alpha'
+        kotlin_version = "1.4.21"
     }
-    ext.kotlin_version = "1.4.21"
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.0-alpha02'
+        classpath 'com.android.tools.build:gradle:7.0.0-alpha03'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$dagger_hilt_version"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Fri Oct 30 23:57:12 CET 2020
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https://services.gradle.org/distributions/gradle-6.7.1-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.8-rc-1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Upgrade AGP 7.0.0-alpha02 to 7.0.0-alpha03
- Upgrade Jetpack Compose 1.0.0-alpha08 to 1.0.0-alpha09
- Upgrade Kotlin version 1.4.20 to 1.4.21
- Upgrade Navigation Compose 1.0.0-alpha03 to 1.0.0-alpha04